### PR TITLE
Add tags endpoint and frontend integration

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -75,6 +75,7 @@ func main() {
 	api.GET("/ingredients", handlers.GetIngredients(db.DB))
 	// tags
 	api.GET("/tags", handlers.GetTags(db.DB))
+	api.POST("/tags", handlers.CreateTag(db.DB))
 
 	fmt.Printf("Starting server on port %s...\n", port)
 	if err := router.Run(":" + port); err != nil {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -73,6 +73,8 @@ func main() {
 
 	// ingredient
 	api.GET("/ingredients", handlers.GetIngredients(db.DB))
+	// tags
+	api.GET("/tags", handlers.GetTags(db.DB))
 
 	fmt.Printf("Starting server on port %s...\n", port)
 	if err := router.Run(":" + port); err != nil {

--- a/backend/internal/handlers/tags.go
+++ b/backend/internal/handlers/tags.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"backend/internal/models"
 	"github.com/gin-gonic/gin"
@@ -16,5 +17,25 @@ func GetTags(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, tags)
+	}
+}
+
+func CreateTag(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input struct {
+			Name string `json:"name"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil || strings.TrimSpace(input.Name) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
+			return
+		}
+
+		tag := models.Tag{Name: strings.Title(strings.ToLower(input.Name))}
+		if err := db.FirstOrCreate(&tag, tag).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create tag"})
+			return
+		}
+
+		c.JSON(http.StatusCreated, tag)
 	}
 }

--- a/backend/internal/handlers/tags.go
+++ b/backend/internal/handlers/tags.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"net/http"
+
+	"backend/internal/models"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func GetTags(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var tags []models.Tag
+		if err := db.Find(&tags).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch tags"})
+			return
+		}
+		c.JSON(http.StatusOK, tags)
+	}
+}

--- a/backend/internal/handlers/tags_test.go
+++ b/backend/internal/handlers/tags_test.go
@@ -1,0 +1,41 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"backend/internal/handlers"
+	"backend/internal/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTagTest() (*gin.Engine, *gorm.DB) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db.AutoMigrate(
+		&models.User{},
+		&models.Recipe{},
+		&models.Ingredient{},
+		&models.RecipeIngredient{},
+		&models.Tag{},
+		&models.RecipeTag{},
+		&models.MenuEntry{},
+	)
+	models.Seed(db)
+	r := gin.Default()
+	r.GET("/tags", handlers.GetTags(db))
+	return r, db
+}
+
+func TestGetTags(t *testing.T) {
+	r, _ := setupTagTest()
+	req, _ := http.NewRequest("GET", "/tags", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+}

--- a/backend/internal/handlers/tags_test.go
+++ b/backend/internal/handlers/tags_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"backend/internal/handlers"
@@ -27,6 +28,7 @@ func setupTagTest() (*gin.Engine, *gorm.DB) {
 	models.Seed(db)
 	r := gin.Default()
 	r.GET("/tags", handlers.GetTags(db))
+	r.POST("/tags", handlers.CreateTag(db))
 	return r, db
 }
 
@@ -37,5 +39,17 @@ func TestGetTags(t *testing.T) {
 	r.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+}
+
+func TestCreateTag(t *testing.T) {
+	r, _ := setupTagTest()
+	body := strings.NewReader(`{"name":"Dessert"}`)
+	req, _ := http.NewRequest("POST", "/tags", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201 Created, got %d", resp.Code)
 	}
 }

--- a/frontend/src/components/AddRecipeModal.vue
+++ b/frontend/src/components/AddRecipeModal.vue
@@ -141,7 +141,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, defineEmits, defineProps } from 'vue'
+import { ref, watch, defineEmits, defineProps, onMounted } from 'vue'
 import api from '../api'
 import IngredientInput from './IngredientInput.vue'
 
@@ -162,6 +162,15 @@ watch(props, () => {
   ingredients.value = [{ name: '', amount: '', unit: '' }]
   selectedTags.value = []
   steps.value = [{ title: '', text: '' }]
+})
+
+onMounted(async () => {
+  try {
+    const res = await api.get('/tags')
+    allTags.value = res.data
+  } catch (err) {
+    console.error('Failed to load tags:', err)
+  }
 })
 
 function addIngredient() {

--- a/frontend/src/components/AddRecipeModal.vue
+++ b/frontend/src/components/AddRecipeModal.vue
@@ -181,7 +181,7 @@ watch(props, () => {
 async function fetchTags() {
   try {
     const res = await api.get('/tags')
-    allTags.value = res.data
+    allTags.value = res.data.map((t: any) => ({ id: t.ID, name: t.Name }))
   } catch (err) {
     console.error('Failed to load tags:', err)
   }

--- a/frontend/src/components/AddRecipeModal.vue
+++ b/frontend/src/components/AddRecipeModal.vue
@@ -70,7 +70,7 @@
           <!-- Tags -->
           <div class="mb-4">
             <label class="block text-sm text-primary mb-2">Tags</label>
-            <div v-if="allTags.length" class="flex flex-wrap gap-3">
+            <div v-if="allTags.length" class="flex flex-wrap gap-3 mb-2">
               <label
                 v-for="tag in allTags"
                 :key="tag.id"
@@ -85,7 +85,20 @@
                 {{ tag.name }}
               </label>
             </div>
-            <div v-else class="text-sm text-secondary">No tags found.</div>
+            <div v-else class="text-sm text-secondary mb-2">No tags found.</div>
+
+            <div class="flex items-center gap-2">
+              <input
+                v-model="newTag"
+                @keydown.enter.prevent="addNewTag"
+                type="text"
+                placeholder="New tag"
+                class="border border-secondary rounded px-2 py-1 text-sm flex-1"
+              />
+              <button type="button" @click="addNewTag" class="text-sm text-accent hover:underline">
+                Add Tag
+              </button>
+            </div>
           </div>
 
           <!-- Steps -->
@@ -153,6 +166,7 @@ const instructions = ref('')
 const ingredients = ref([{ name: '', amount: '', unit: '' }])
 const selectedTags = ref<string[]>([])
 const allTags = ref<{ id: number; name: string }[]>([])
+const newTag = ref('')
 const steps = ref([{ title: '', text: '' }])
 
 watch(props, () => {
@@ -164,14 +178,23 @@ watch(props, () => {
   steps.value = [{ title: '', text: '' }]
 })
 
-onMounted(async () => {
+async function fetchTags() {
   try {
     const res = await api.get('/tags')
     allTags.value = res.data
   } catch (err) {
     console.error('Failed to load tags:', err)
   }
-})
+}
+
+onMounted(fetchTags)
+
+watch(
+  () => props.visible,
+  (val) => {
+    if (val) fetchTags()
+  }
+)
 
 function addIngredient() {
   ingredients.value.push({ name: '', amount: '', unit: '' })
@@ -181,6 +204,18 @@ function addStep() {
   if (steps.value.length < 10) {
     steps.value.push({ title: '', text: '' })
   }
+}
+
+function addNewTag() {
+  const tag = newTag.value.trim()
+  if (!tag) return
+  if (!selectedTags.value.includes(tag)) {
+    selectedTags.value.push(tag)
+  }
+  if (!allTags.value.some(t => t.name === tag)) {
+    allTags.value.push({ id: 0, name: tag })
+  }
+  newTag.value = ''
 }
 
 async function submit() {

--- a/frontend/src/components/EditRecipeModal.vue
+++ b/frontend/src/components/EditRecipeModal.vue
@@ -75,7 +75,7 @@
           <!-- Tags -->
           <div class="mb-4">
             <label class="block text-sm text-primary mb-2">Tags</label>
-            <div v-if="allTags.length" class="flex flex-wrap gap-3">
+            <div v-if="allTags.length" class="flex flex-wrap gap-3 mb-2">
               <label
                 v-for="tag in allTags"
                 :key="tag.id"
@@ -90,7 +90,20 @@
                 {{ tag.name }}
               </label>
             </div>
-            <div v-else class="text-sm text-secondary">No tags found.</div>
+            <div v-else class="text-sm text-secondary mb-2">No tags found.</div>
+
+            <div class="flex items-center gap-2">
+              <input
+                v-model="newTag"
+                @keydown.enter.prevent="addNewTag"
+                type="text"
+                placeholder="New tag"
+                class="border border-secondary rounded px-2 py-1 text-sm flex-1"
+              />
+              <button type="button" @click="addNewTag" class="text-sm text-accent hover:underline">
+                Add Tag
+              </button>
+            </div>
           </div>
 
           <!-- Steps -->
@@ -158,6 +171,7 @@ const ingredients = ref<any[]>([])
 const steps = ref<any[]>([])
 const selectedTags = ref<string[]>([])
 const allTags = ref<{ id: number; name: string }[]>([])
+const newTag = ref('')
 
 watch(
   () => props.recipe,
@@ -210,14 +224,35 @@ async function submit() {
   }
 }
 
-onMounted(async () => {
+async function fetchTags() {
   try {
     const res = await api.get('/tags')
     allTags.value = res.data
   } catch (err) {
     console.error('Failed to load tags:', err)
   }
-})
+}
+
+onMounted(fetchTags)
+
+watch(
+  () => props.recipe,
+  (val) => {
+    if (val) fetchTags()
+  }
+)
+
+function addNewTag() {
+  const tag = newTag.value.trim()
+  if (!tag) return
+  if (!selectedTags.value.includes(tag)) {
+    selectedTags.value.push(tag)
+  }
+  if (!allTags.value.some(t => t.name === tag)) {
+    allTags.value.push({ id: 0, name: tag })
+  }
+  newTag.value = ''
+}
 </script>
 
 <style scoped>

--- a/frontend/src/components/EditRecipeModal.vue
+++ b/frontend/src/components/EditRecipeModal.vue
@@ -227,7 +227,7 @@ async function submit() {
 async function fetchTags() {
   try {
     const res = await api.get('/tags')
-    allTags.value = res.data
+    allTags.value = res.data.map((t: any) => ({ id: t.ID, name: t.Name }))
   } catch (err) {
     console.error('Failed to load tags:', err)
   }

--- a/frontend/src/views/RecipeList.vue
+++ b/frontend/src/views/RecipeList.vue
@@ -56,7 +56,7 @@
           </ul>
         </div>
 
-        <div v-if="recipe.Tags?.length">
+        <div v-if="recipe.Tags?.length" class="mt-3">
           <span
             v-for="tag in recipe.Tags"
             :key="tag.ID"

--- a/frontend/src/views/RecipeList.vue
+++ b/frontend/src/views/RecipeList.vue
@@ -102,18 +102,8 @@ async function fetchRecipes() {
   }
 }
 
-async function handleCreate(data: { title: string; instructions: string }) {
-  try {
-    await api.post('/recipes', {
-      title: data.title,
-      instructions: data.instructions,
-    })
-    await fetchRecipes()
-  } catch (err) {
-    console.error('Error creating recipe:', err)
-  } finally {
-    showModal.value = false
-  }
+async function handleCreate() {
+  await fetchRecipes()
 }
 
 const editingRecipe = ref(null)

--- a/frontend/src/views/RecipeSingleView.vue
+++ b/frontend/src/views/RecipeSingleView.vue
@@ -1,6 +1,15 @@
 <template>
   <div class="p-6">
-    <h1 class="text-3xl font-bold text-primary mb-6 text-center">{{ recipe.Title }}</h1>  
+    <h1 class="text-3xl font-bold text-primary mb-4 text-center">{{ recipe.Title }}</h1>
+    <div v-if="recipe.Tags && recipe.Tags.length" class="flex flex-wrap gap-2 justify-center mb-6">
+      <span
+        v-for="tag in recipe.Tags"
+        :key="tag.ID"
+        class="bg-secondary text-primary text-xs px-2 py-1 rounded"
+      >
+        {{ tag.Tag?.Name }}
+      </span>
+    </div>
     <div class="flex flex-col lg:flex-row gap-6">
         <!-- Left Sidebar (Ingredients + Portions) -->
         <div class="lg:w-1/4 w-full bg-white border border-secondary rounded-xl p-4 shadow">


### PR DESCRIPTION
## Summary
- support listing tags via `/api/tags`
- fetch tags when adding a recipe
- refresh recipe list after creating a recipe
- add Go test for new endpoint

## Testing
- `go test ./internal/handlers -run TestGetTags -v`
- `go test ./...` *(fails: no test files or other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686957fc20a4832bb556a7b1e7cdfe73