### PR TITLE
Add recipe search by name or tag

### DIFF
--- a/backend/internal/handlers/recipes_test.go
+++ b/backend/internal/handlers/recipes_test.go
@@ -37,6 +37,7 @@ func setupTestDB() *gorm.DB {
 		&models.Tag{},
 		&models.RecipeTag{},
 		&models.MenuEntry{},
+		&models.RecipeStep{},
 	)
 	models.Seed(db)
 	return db
@@ -53,6 +54,37 @@ func TestGetAllRecipes(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", resp.Code)
 	}
+}
+
+func TestSearchRecipesByTitle(t *testing.T) {
+	db := setupTestDB()
+	r := setupTestRouter(db)
+
+	req, _ := http.NewRequest("GET", "/recipes?search=panc", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	var recipes []models.Recipe
+	json.NewDecoder(resp.Body).Decode(&recipes)
+	assert.Equal(t, 1, len(recipes))
+	assert.Equal(t, "Simple Pancakes", recipes[0].Title)
+}
+
+func TestSearchRecipesByTag(t *testing.T) {
+	db := setupTestDB()
+	r := setupTestRouter(db)
+
+	req, _ := http.NewRequest("GET", "/recipes?search=vega", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	var recipes []models.Recipe
+	json.NewDecoder(resp.Body).Decode(&recipes)
+	assert.GreaterOrEqual(t, len(recipes), 1)
 }
 
 func TestCreateRecipe(t *testing.T) {

--- a/frontend/src/views/RecipeList.vue
+++ b/frontend/src/views/RecipeList.vue
@@ -9,29 +9,28 @@
   />
 
   <div class="bg-background min-h-screen p-4">
-    <div class="flex justify-between items-center mb-6 pb-2 border-b border-secondary">
+    <div class="flex flex-wrap items-center justify-between gap-2 mb-6 pb-2 border-b border-secondary">
       <h1 class="text-xl font-semibold text-primary">Recipes</h1>
+      <div class="flex gap-2 flex-1 sm:flex-none">
+        <input
+          v-model="search"
+          @keydown.enter.prevent="loadRecipes"
+          type="text"
+          placeholder="Search by name or tag"
+          class="flex-1 border border-secondary rounded px-3 py-2"
+        />
+        <button
+          class="bg-accent text-white px-4 py-2 rounded hover:bg-primary transition-colors"
+          @click="loadRecipes"
+        >
+          Search
+        </button>
+      </div>
       <button
         class="bg-accent text-white px-4 py-2 rounded hover:bg-primary transition-colors"
         @click="showModal = true"
       >
         + Add Recipe
-      </button>
-    </div>
-
-    <div class="flex gap-2 mb-4">
-      <input
-        v-model="search"
-        @keydown.enter.prevent="loadRecipes"
-        type="text"
-        placeholder="Search by name or tag"
-        class="flex-1 border border-secondary rounded px-3 py-2"
-      />
-      <button
-        class="bg-accent text-white px-4 py-2 rounded hover:bg-primary transition-colors"
-        @click="loadRecipes"
-      >
-        Search
       </button>
     </div>
 

--- a/frontend/src/views/RecipeList.vue
+++ b/frontend/src/views/RecipeList.vue
@@ -1,9 +1,5 @@
 <template>
-  <AddRecipeModal
-    :visible="showModal"
-    @close="showModal = false"
-    @submit="handleCreate"
-  />
+  <AddRecipeModal :visible="showModal" @close="showModal = false" @submit="handleCreate" />
 
   <EditRecipeModal
     v-if="editingRecipe"
@@ -20,6 +16,22 @@
         @click="showModal = true"
       >
         + Add Recipe
+      </button>
+    </div>
+
+    <div class="flex gap-2 mb-4">
+      <input
+        v-model="search"
+        @keydown.enter.prevent="loadRecipes"
+        type="text"
+        placeholder="Search by name or tag"
+        class="flex-1 border border-secondary rounded px-3 py-2"
+      />
+      <button
+        class="bg-accent text-white px-4 py-2 rounded hover:bg-primary transition-colors"
+        @click="loadRecipes"
+      >
+        Search
       </button>
     </div>
 
@@ -66,10 +78,7 @@
           </span>
         </div>
 
-        <button
-          class="text-sm text-accent hover:underline mt-2"
-          @click="startEdit(recipe)"
-        >
+        <button class="text-sm text-accent hover:underline mt-2" @click="startEdit(recipe)">
           Edit
         </button>
       </div>
@@ -86,6 +95,7 @@ import EditRecipeModal from '../components/EditRecipeModal.vue'
 const recipes = ref([])
 const loading = ref(true)
 const showModal = ref(false)
+const search = ref('')
 
 onMounted(async () => {
   await fetchRecipes()
@@ -93,7 +103,9 @@ onMounted(async () => {
 
 async function fetchRecipes() {
   try {
-    const res = await api.get('/recipes')
+    const params: any = {}
+    if (search.value.trim()) params.search = search.value
+    const res = await api.get('/recipes', { params })
     recipes.value = res.data
   } catch (err) {
     console.error('Error loading recipes:', err)
@@ -102,8 +114,13 @@ async function fetchRecipes() {
   }
 }
 
-async function handleCreate() {
+async function loadRecipes() {
+  loading.value = true
   await fetchRecipes()
+}
+
+async function handleCreate() {
+  await loadRecipes()
 }
 
 const editingRecipe = ref(null)


### PR DESCRIPTION
## Summary
- support searching recipes by title or tag
- test recipe search on the backend
- add search bar to recipe list view

## Testing
- `npm run lint` *(fails: The 'jiti' library is required for loading TypeScript configuration files)*
- `npm run build` *(fails: vite: not found)*
- `go test ./...` *(fails: TestGetMenuEntries, TestCreateMenuEntry, TestDeleteMenuEntry, TestGetShoppingListInvalidUser)*

------
https://chatgpt.com/codex/tasks/task_e_686a90c253cc832baaf484bec1b49393